### PR TITLE
Remove external.xx.fbcdn.net

### DIFF
--- a/adaway-export
+++ b/adaway-export
@@ -203,7 +203,6 @@
 127.0.0.1 impact.applifier.com
 127.0.0.1 oimagec1.ydstatic.com
 127.0.0.1 ads.avocet.io
-127.0.0.1 external.xx.fbcdn.net
 127.0.0.1 manifest.localytics.com
 127.0.0.1 api.vungle.com
 127.0.0.1 rpc.tapjoy.com


### PR DESCRIPTION
This is a Facebook Content Delivery Network (CDN) and delivers static images and resources
This breaks images/thumbnails in FB Messenger

Also please open up Github Issues so I can create issues as opposed to only pull requests
Thanks!

@34730 